### PR TITLE
Fix Parquet error when loading text files

### DIFF
--- a/benchmark_qed/autod/io/document.py
+++ b/benchmark_qed/autod/io/document.py
@@ -80,7 +80,7 @@ def load_text_doc(
         title=str(file_path.replace(".txt", "")),
         type="text",
         text=text,
-        attributes={},
+        attributes=None,
     )
 
 


### PR DESCRIPTION
Fixes Parquet error: `cannot write struct with no child field` that was being raised when loading input from text files using `benchmark_qed.autod.sampler.sample_gen.acreate_clustered_sample()`.

Changed `benchmark_qed.autod.io.document.load_text_doc()` to set `attributes = None` instead of `{}`.

Fixes #19 