### PR TITLE
Pass llm_params through to claim_extractor

### DIFF
--- a/.semversioner/next-release/patch-20260622215607308688.json
+++ b/.semversioner/next-release/patch-20260622215607308688.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Pass llm_config through to claim_extractor"
+}

--- a/benchmark_qed/autoq/question_gen/data_questions/global_question_gen.py
+++ b/benchmark_qed/autoq/question_gen/data_questions/global_question_gen.py
@@ -175,7 +175,7 @@ class DataGlobalQuestionGen(BaseQuestionGen):
         from benchmark_qed.autoq.config import AssertionConfig, AssertionPromptConfig
 
         if claim_extractor_params is None:
-            claim_extractor_params = {}
+            claim_extractor_params = {"llm_params": llm_params}
         if assertion_config is None:
             assertion_config = AssertionConfig()
         if assertion_prompt_config is None:


### PR DESCRIPTION
Fixing issue #99

When an llm_params object is passed to DataLocalQuestionGen's constructor but claim_extractor_params isn't, pass through llm_params to claim_extractor_params.

This causes behavior to be consistent by default